### PR TITLE
(Possibly Temporary Issue) DF 10.2.6 ilvl labels showing on non-equippables

### DIFF
--- a/BlizzardBags_ItemLevel/main.lua
+++ b/BlizzardBags_ItemLevel/main.lua
@@ -136,7 +136,7 @@ local Update = function(self, bag, slot)
 			end
 
 
-		elseif (itemQuality and itemQuality > 0 and itemEquipLoc and _G[itemEquipLoc]) then
+		elseif (itemQuality and itemQuality > 0 and itemEquipLoc and _G[itemEquipLoc] ~= "") then
 
 			local tipLevel
 


### PR DESCRIPTION
As the title says, the most recent retail patch made many unequippable items have ilvl labels such as consumables and crafting reagents.
![image](https://github.com/GoldpawsStuff/BlizzardBags_ItemLevel/assets/45940352/347524ce-106a-472f-b2d2-2f5f7a07ff7c)
For some reason this patch added INVTYPE_NON_EQUIP_IGNORE which many items return as ItemEquipLoc.
For example Frostweave Cloth:
![image](https://github.com/GoldpawsStuff/BlizzardBags_ItemLevel/assets/45940352/c6ebb17d-c167-4442-bc5f-e038fcdeac3c)

Patch 10.2.5:
![image](https://github.com/GoldpawsStuff/BlizzardBags_ItemLevel/assets/45940352/6c76a524-98c7-4c0b-838f-9c0a9214055e)

Patch 10.2.6:
![image](https://github.com/GoldpawsStuff/BlizzardBags_ItemLevel/assets/45940352/98dff934-41e4-4918-bf03-248e13fd18e4)
I'm not sure why they can get their ilvl values, but filtering them out of the if statement works correctly.

![image](https://github.com/GoldpawsStuff/BlizzardBags_ItemLevel/assets/45940352/cd759ed7-c2f1-4439-b3a6-e9d302d6568f)
Easy to change the regular NON_EQUIP string if Blizz removes the IGNORE one later.


